### PR TITLE
Allow digits in frame prefix

### DIFF
--- a/example.c
+++ b/example.c
@@ -18,12 +18,24 @@ int main(int argc, char const* argv[]) {
     printf("Frame: \"%s\"\n", f);         // Print generated frame
     valid = frames_verify(f, FRAME_LEN);  // Check if it is valid
     printf("Valid: %d\n", valid);         // Print if frame is valid
-    uint8_t data[3] =
+    uint8_t data1[3] =
         "\0\0\0";  // Buffer for data which will be extracted from frame
-    frames_read_data(f, FRAME_LEN, data);  // Extract data from frame
-    printf("Data: \"%s\"\n", data);        // Print this data
-    uint8_t len = frames_len_data(f);      // Get data's length
-    printf("Data length: %d\n", len);      // Print data's length
+    frames_read_data(f, FRAME_LEN, data1);  // Extract data from frame
+    printf("Data: \"%s\"\n", data1);        // Print this data
+    uint8_t len = frames_len_data(f);       // Get data's length
+    printf("Data length: %d\n\n", len);     // Print data's length
+
+    frames_create(f, FRAME_LEN, (uint8_t*)"M1",
+                  (uint8_t*)"OK");        // Create frame
+    printf("Frame: \"%s\"\n", f);         // Print generated frame
+    valid = frames_verify(f, FRAME_LEN);  // Check if it is valid
+    printf("Valid: %d\n", valid);         // Print if frame is valid
+    uint8_t data2[3] =
+        "\0\0\0";  // Buffer for data which will be extracted from frame
+    frames_read_data(f, FRAME_LEN, data2);  // Extract data from frame
+    printf("Data: \"%s\"\n", data2);        // Print this data
+    len = frames_len_data(f);               // Get data's length
+    printf("Data length: %d\n", len);       // Print data's length
 
     return 0;
 }

--- a/frames.c
+++ b/frames.c
@@ -33,11 +33,13 @@ uint8_t frames_len_data(uint8_t* frame) {
 }
 
 bool frames_verify(uint8_t* frame, uint8_t frame_len) {
-    if (frame[0] < 'A' || frame[0] > 'Z') {
+    if ((frame[0] < 'A' || frame[0] > 'Z') &&
+        (frame[0] < '0' || frame[0] > '9')) {
         return false;
     }
 
-    if (frame[1] < 'A' || frame[1] > 'Z') {
+    if ((frame[1] < 'A' || frame[1] > 'Z') &&
+        (frame[1] < '0' || frame[1] > '9')) {
         return false;
     }
 


### PR DESCRIPTION
I created a commit that also allows to use digits in frame header, in example `M1`, `M2`, etc.